### PR TITLE
TMCP 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # tmcp
+
 ## Helper classes for the Team Match Communication Protocol
 
 Learn more about [TMCP](https://github.com/RLBot/RLBot/wiki/Team-Match-Communication-Protocol).
@@ -63,15 +64,15 @@ if self.backlog:
         self.backlog.insert(0, backlog_message)
 ```
 
-## Avoiding breaking changes
+## Avoiding major breaking changes
 
 This package is regularly updated according to the latest TMCP specification.
-To avoid your bot breaking during tournaments, you can use a virtual_environment and pin a specific version of this package.
+To avoid your bot breaking during tournaments due to major version updates, you can use a virtual_environment and pin a specific version of this package.
 
 In your requirements.txt:
 
 ```txt
-tmcp==0.9
+tmcp==1.*
 ```
 
 In your bot.cfg:
@@ -88,6 +89,6 @@ This will not send or receive any messages, but will pretend as if it was sendin
 ```py
 from tmcp import TMCP_VERSION
 
-if TMCP_VERSION != [0, 9]:
+if TMCP_VERSION[0] != 1:
     my_handler.disable()
 ```

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as readme_file:
 setup(
     name="tmcp",
     packages=["tmcp"],
-    version="0.1.0",
+    version="1.0.0",
     license="MIT",
     description="Helper classes for the Team Match Communication Protocol.",
     long_description=long_description,
@@ -14,7 +14,7 @@ setup(
     author="Viliam Vadocz",
     author_email="viliam.vadocz@gmail.com",
     url="https://github.com/ViliamVadocz/tmcp/",
-    download_url="https://github.com/ViliamVadocz/tmcp/archive/v_0_9_1.tar.gz",
+    download_url="https://github.com/ViliamVadocz/tmcp/archive/v_1_0_0.tar.gz",
     keywords=["RLBot", "protocol"],
     install_requires=["rlbot"],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as readme_file:
 setup(
     name="tmcp",
     packages=["tmcp"],
-    version="0.9.1",
+    version="0.1.0",
     license="MIT",
     description="Helper classes for the Team Match Communication Protocol.",
     long_description=long_description,

--- a/tmcp/__init__.py
+++ b/tmcp/__init__.py
@@ -1,3 +1,3 @@
-TMCP_VERSION = [0, 9]
+TMCP_VERSION = [1, 0]
 from tmcp.handler import TMCPHandler
 from tmcp.message import TMCPMessage, ActionType

--- a/tmcp/handler.py
+++ b/tmcp/handler.py
@@ -92,9 +92,6 @@ class TMCPHandler:
         return messages
 
     def parse(self, message: dict) -> Optional[TMCPMessage]:
-        # Ignore messages using a different version of the protocol.
-        if message.get("tmcp_version") != TMCP_VERSION:
-            return None
         # Ignore messages by opposing team.
         if message.get("team") != self.team:
             return None

--- a/tmcp/message.py
+++ b/tmcp/message.py
@@ -91,7 +91,8 @@ class TMCPMessage:
                 direction = action.get("direction", [0.0, 0.0, 0.0])
                 assert isinstance(direction, (list, tuple))
                 assert len(direction) in (2, 3)
-                if len(direction) == 2: direction.append(0.0)
+                if len(direction) == 2:
+                    direction = [direction[0], direction[1], 0.0]
                 assert all(isinstance(elem, (int, float)) for elem in direction)
                 msg = cls.ball_action(team, index, float(action_time), direction)
             elif action_type == ActionType.BOOST:

--- a/tmcp/message.py
+++ b/tmcp/message.py
@@ -78,28 +78,35 @@ class TMCPMessage:
             assert isinstance(team, int)
             assert isinstance(index, int)
 
+            version = message["tmcp_version"]
+            assert isinstance(version, (list, tuple))
+            assert len(version) == 2
+            
             action: dict = message["action"]
-            action_type: ActionType = ActionType(action["type"])
+            action_type: ActionType = ActionType(action["type"].upper())
 
             if action_type == ActionType.BALL:
-                assert isinstance(action["time"], (float, int))
-                direction = action["direction"]
+                action_time = action.get("time", -1)
+                assert isinstance(action_time, (float, int))
+                direction = action.get("direction", [0.0, 0.0, 0.0])
                 assert isinstance(direction, (list, tuple))
                 assert len(direction) in (2, 3)
                 assert all(isinstance(elem, (int, float)) for elem in direction)
-                msg = cls.ball_action(team, index, float(action["time"]), direction)
+                msg = cls.ball_action(team, index, float(action_time), direction)
             elif action_type == ActionType.BOOST:
                 assert isinstance(action["target"], int)
                 msg = cls.boost_action(team, index, action["target"])
             elif action_type == ActionType.DEMO:
                 assert isinstance(action["target"], int)
-                assert isinstance(action["time"], (float, int))
+                action_time = action.get("time", -1)
+                assert isinstance(action_time, (float, int))
                 msg = cls.demo_action(
-                    team, index, action["target"], float(action["time"])
+                    team, index, action["target"], float(action_time)
                 )
             elif action_type == ActionType.READY:
-                assert isinstance(action["time"], (float, int))
-                msg = cls.ready_action(team, index, float(action["time"]))
+                action_time = action.get("time", -1)
+                assert isinstance(action_time, (float, int))
+                msg = cls.ready_action(team, index, float(action_time))
             elif action_type == ActionType.DEFEND:
                 msg = cls.defend_action(team, index)
             else:

--- a/tmcp/message.py
+++ b/tmcp/message.py
@@ -91,6 +91,7 @@ class TMCPMessage:
                 direction = action.get("direction", [0.0, 0.0, 0.0])
                 assert isinstance(direction, (list, tuple))
                 assert len(direction) in (2, 3)
+                if len(direction) == 2: direction.append(0.0)
                 assert all(isinstance(elem, (int, float)) for elem in direction)
                 msg = cls.ball_action(team, index, float(action_time), direction)
             elif action_type == ActionType.BOOST:


### PR DESCRIPTION
Version bump on everything
Changed readme to tell users to avoid major breaking changes via checking the major version of TMCP (all breaking changes will now be complemented by a major version increase)
Downloading the latest release for any major version 1 package
Much more flexible parsing of packets:

- Packets won't be ignored if they have dissimilar versions, only invalid versions
- `type` key under `action` is automatically capitalized
- If the `time` key in the actions `BALL`, `READY` or `DEMO` isn't present, they will be set to their default value (`-1`).
- If the `direction` key in the action `BALL` isn't present, it will be set to its default value (`[0, 0, 0]`).
- If the `direction` key in the action `BALL` has only 2 elements, a third `0` will be appended.

Missing non-optional values will still result in the packet being flagged as invalid.